### PR TITLE
Org Logo Distortion Fix

### DIFF
--- a/justin-ventura-portfolio/src/components/Portfolio/Bio.js
+++ b/justin-ventura-portfolio/src/components/Portfolio/Bio.js
@@ -46,27 +46,27 @@ function Bio({ emphasis }) {
               <div className="grid grid-cols-5 mt-10">
                 <img
                   src={amazonTransparent}
-                  className="col-span-1 h-24 w-32 my-3 justify-center"
+                  className="col-span-1 h-24 w-32 my-3 justify-center object-contain"
                   alt="logo"
                 />
                 <img
                   src={cmuTransparent}
-                  className="col-span-1 h-24 w-24 ml-4 my-3 justify-center"
+                  className="col-span-1 h-24 w-24 ml-4 my-3 justify-center object-contain"
                   alt="logo"
                 />
                 <img
                   src={googleTransparent}
-                  className="col-span-1 h-24 w-24 my-3 justify-center"
+                  className="col-span-1 h-24 w-24 my-3 justify-center object-contain"
                   alt="logo"
                 />
                 <img
                   src={metaTransparent}
-                  className="col-span-1 h-24 w-24 mr-4 my-3 justify-center"
+                  className="col-span-1 h-24 w-24 mr-4 my-3 justify-center object-contain"
                   alt="logo"
                 />
                 <img
                   src={umdTransparent}
-                  className="bg-white rounded-full col-span-1 h-24 w-24 ml-4 my-3 justify-center"
+                  className="bg-white rounded-full col-span-1 h-24 w-24 ml-4 my-3 justify-center object-contain"
                   alt="logo"
                 />
               </div>


### PR DESCRIPTION
Fix org logo distortion on different viewports by setting image resizing property to stay contained within its container using object-fit

Before:
![Screenshot Capture - 2023-03-01 - 12-31-42](https://user-images.githubusercontent.com/35266067/222217225-834e7c20-0edb-4c07-bc95-0ebbcc5969ea.png)

After:
![Screenshot Capture - 2023-03-01 - 12-31-47](https://user-images.githubusercontent.com/35266067/222217235-06803250-ba4d-42b9-87a0-227a14ba36db.png)
